### PR TITLE
Replace usePlugin with require/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ npm install --save-dev @tenderly/hardhat-tenderly
 And add the following statement to your `hardhat.config.js`:
 
 ```js
-usePlugin("@tenderly/hardhat-tenderly");
+require("@tenderly/hardhat-tenderly");
+```
+
+Or, if you are using typescript:
+
+```ts
+import "@tenderly/hardhat-tenderly"
 ```
 
 ## Tasks


### PR DESCRIPTION
Hardhat doesn't use `usePlugin` anymore. Instead, the module needs to be required or imported.