### PR TITLE
add support for matic mainnet + minor error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export const NetworkMap: Record<string, string> = {
   mainnet: "1",
   rinkeby: "4",
   ropsten: "3",
+  matic: "137",
   mumbai: "80001",
   xDai: "100",
   POA: "99"
@@ -35,6 +36,7 @@ export const ReverseNetworkMap: Record<string, string> = {
   "1": "mainnet",
   "4": "rinkeby",
   "3": "ropsten",
+  "137": "matic",
   "80001": "mumbai",
   "100": "xDai",
   "99": "POA"

--- a/src/tenderly/TenderlyService.ts
+++ b/src/tenderly/TenderlyService.ts
@@ -23,6 +23,10 @@ export class TenderlyService {
       const responseData: ContractResponse = response.data;
 
       let contract: ApiContract;
+      
+      if(!responseData.contracts?.length){
+        throw Error('Empty Contracts Response')
+      }
 
       console.log("Smart Contracts successfully verified");
       console.group();


### PR DESCRIPTION
hey!

this PR adds support for matic mainnet network ID, and minor error handling change that avoids confusing error output such as 

```
Smart Contracts successfully verified
  Error in hardhat-tenderly: There was an error during the request. Contract verification failed
```

