### PR TITLE
Contract network patch

### DIFF
--- a/src/Tenderly.ts
+++ b/src/Tenderly.ts
@@ -145,7 +145,8 @@ export class Tenderly {
     for (contract of flatContracts) {
       const network =
         this.env.hardhatArguments.network !== "hardhat"
-          && (this.env.hardhatArguments.network || contract.network);
+          ? (this.env.hardhatArguments.network || contract.network)
+          : contract.network;
       if (network === undefined) {
         console.log(
           `Error in ${PluginName}: Please provide a network via the hardhat --network argument or directly in the contract`

--- a/src/Tenderly.ts
+++ b/src/Tenderly.ts
@@ -145,8 +145,7 @@ export class Tenderly {
     for (contract of flatContracts) {
       const network =
         this.env.hardhatArguments.network !== "hardhat"
-          ? this.env.hardhatArguments.network
-          : contract.network;
+          && (this.env.hardhatArguments.network || contract.network);
       if (network === undefined) {
         console.log(
           `Error in ${PluginName}: Please provide a network via the hardhat --network argument or directly in the contract`


### PR DESCRIPTION
I was trying to verify to Kovan in the absence of a --network:
```
  await tenderly.verify({
    name: "YourContract",
    address: "0xa983e6e57b95c2e47cEE88B6a6bd67452fA9D24D",//yourContract.address,
    network: "kovan"
  })```
I got the following error:
`Error in hardhat-tenderly: Please provide a network via the hardhat --network argument or directly in the contract`

This change falls back to use `contract.network` if `this.env.hardhatArguments.network` is undefined