### PR TITLE
fix: use network metadata slug only when it exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,10 @@ const populateNetworks = (env: HardhatRuntimeEnvironment): void => {
       let slug: string;
       for (network of networks) {
         NetworkMap[network.slug] = network.ethereum_network_id;
-        NetworkMap[network.metadata.slug] = network.ethereum_network_id;
+        
+        if (network?.metadata?.slug) {
+          NetworkMap[network.metadata.slug] = network.ethereum_network_id;
+        }
 
         ReverseNetworkMap[network.ethereum_network_id] = network.slug;
 


### PR DESCRIPTION
Fixes #26 