### PR TITLE
Removing `forkNetwork` as mandatory field in TenderlyConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tenderly/hardhat-tenderly",
   "description": "Hardhat plugin for integration with Tenderly",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {

--- a/src/TenderlyNetwork.ts
+++ b/src/TenderlyNetwork.ts
@@ -179,6 +179,10 @@ export class TenderlyNetwork {
     if (!this.checkNetwork()) {
       return;
     }
+    if (!this.env.config.tenderly?.forkNetwork) {
+      return;
+    }
+
     const username: string = this.env.config.tenderly.username;
     const projectID: string = this.env.config.tenderly.project;
     try {

--- a/src/tenderly/types/utils.ts
+++ b/src/tenderly/types/utils.ts
@@ -14,7 +14,7 @@ export interface BytecodeMismatchError {
 export interface TenderlyConfig {
   project: string;
   username: string;
-  forkNetwork: string;
+  forkNetwork?: string;
   privateVerification?: boolean;
   deploymentsDir?: string;
 }


### PR DESCRIPTION
Addressing raised breaking change introduced in `v1.1.0` in #47 