### PR TITLE
Fix ethers override

### DIFF
--- a/packages/tenderly-hardhat/src/index.ts
+++ b/packages/tenderly-hardhat/src/index.ts
@@ -1,8 +1,10 @@
 import "@nomiclabs/hardhat-ethers";
-import "./tenderly/extender";
 import "./type-extensions";
 import "./tasks";
 
+import * as tenderlyExtender from "./tenderly/extender";
+
 export function setup({ automaticVerifications = false }): void {
   process.env.AUTOMATIC_VERIFICATION_ENABLED = automaticVerifications === true ? "true" : "false";
+  tenderlyExtender.setup();
 }

--- a/packages/tenderly-hardhat/src/tenderly/extender.ts
+++ b/packages/tenderly-hardhat/src/tenderly/extender.ts
@@ -19,15 +19,17 @@ import { wrapHHDeployments } from "./hardhat-deploy";
 
 const tenderlyService = new TenderlyService(PLUGIN_NAME);
 
-extendEnvironment((hre: HardhatRuntimeEnvironment) => {
-  hre.tenderly = lazyObject(() => new Tenderly(hre));
-  extendProvider(hre);
-  populateNetworks();
-  if (process.env.AUTOMATIC_VERIFICATION_ENABLED === "true") {
-    extendEthers(hre);
-    extendHardhatDeploy(hre);
-  }
-});
+export function setup() {
+  extendEnvironment((hre: HardhatRuntimeEnvironment) => {
+    hre.tenderly = lazyObject(() => new Tenderly(hre));
+    extendProvider(hre);
+    populateNetworks();
+    if (process.env.AUTOMATIC_VERIFICATION_ENABLED === "true") {
+      extendEthers(hre);
+      extendHardhatDeploy(hre);
+    }
+  });
+}
 
 extendConfig((resolvedConfig: HardhatConfig) => {
   resolvedConfig.networks.tenderly = {


### PR DESCRIPTION
This is needed to be done like this because if hardhat/ethers override ethers and if it is imported below @tenderly/hardhat-tenderly it will override our automatic verification implementation on ethers.