### PR TITLE
Downgraded linter version

### DIFF
--- a/packages/tenderly-core/package.json
+++ b/packages/tenderly-core/package.json
@@ -39,7 +39,7 @@
     "@types/prompts": "^2.0.14",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
-    "eslint": "^8.23.0",
+    "eslint": "8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/tenderly-hardhat/package.json
+++ b/packages/tenderly-hardhat/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^18.7.15",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
-    "eslint": "^8.23.0",
+    "eslint": "8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
I am downgrading linter minor version since there is a bug in `GoLand` in version `8.23.0` of the linter.
This bug is not found in linter version `8.22.0`.
The explanation can be found [here](https://stackoverflow.com/questions/73509984/eslint-typeerror-this-liboptions-parse-is-not-a-function).