### PR TITLE
add via-ir compile flag

### DIFF
--- a/packages/tenderly-core/src/internal/core/types/Contract.ts
+++ b/packages/tenderly-core/src/internal/core/types/Contract.ts
@@ -4,6 +4,7 @@ export interface TenderlyContractConfig {
   optimizations_count?: number;
   evm_version?: string;
   debug?: CompilerDebugInput;
+  via_ir?: boolean
 }
 
 export interface CompilerDebugInput {

--- a/packages/tenderly-core/src/internal/core/types/Contract.ts
+++ b/packages/tenderly-core/src/internal/core/types/Contract.ts
@@ -4,7 +4,7 @@ export interface TenderlyContractConfig {
   optimizations_count?: number;
   evm_version?: string;
   debug?: CompilerDebugInput;
-  via_ir?: boolean
+  via_ir?: boolean;
 }
 
 export interface CompilerDebugInput {


### PR DESCRIPTION
Via-ir option would be set on the web page. However Hardhat-tendrly plugin does not expose it.
It would be need to verify contract which use via-ir flag to avoid bytes mismatch error. 
I had an issue with byte mismatch which is caused by via-ir flag then added this property, and this issue was resolved.