### PR TITLE
Fix wrong import

### DIFF
--- a/.changeset/angry-phones-train.md
+++ b/.changeset/angry-phones-train.md
@@ -1,0 +1,5 @@
+---
+"@tenderly/hardhat-tenderly": patch
+---
+
+Fixed wrong import.

--- a/packages/tenderly-hardhat/src/tenderly/types/utils.ts
+++ b/packages/tenderly-hardhat/src/tenderly/types/utils.ts
@@ -1,4 +1,4 @@
-import { ContractCompiler } from "tenderly/src/types";
+import { ContractCompiler } from "tenderly/types";
 
 export interface BytecodeMismatchError {
   contract_id: string;


### PR DESCRIPTION
We cannot import from `src` since it is our build directory. It won't be shown to the users.