### PR TITLE
Move hardhat from dep to devDep

### DIFF
--- a/packages/tenderly-hardhat/package.json
+++ b/packages/tenderly-hardhat/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "hardhat": "^2.10.2",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
@@ -53,14 +54,12 @@
     "axios": "^0.27.2",
     "ethers": "^5.7.0",
     "fs-extra": "^10.1.0",
-    "hardhat": "^2.10.2",
     "hardhat-deploy": "^0.11.14",
     "js-yaml": "^4.1.0",
     "tenderly": "^0.5.0",
     "tslog": "^4.3.1"
   },
   "peerDependencies": {
-    "hardhat": "^2.10.2",
-    "tenderly": "^0.5.0"
+    "hardhat": "^2.10.2"
   }
 }


### PR DESCRIPTION
Hi, this repo has two peer dependencies (`hardhat` and `tenderly`) that are also plain dependencies. This is usually an error and can be problematic. For example, @pcaversaccio's [template repo](https://github.com/pcaversaccio/hardhat-project-template-ts) now gets an error if you try to upgrade an unrelated package (`hardhat-ethers`) because of that.

This PR fixes the problem by moving Hardhat to `devDependencies`, and by removing `tenderly` as a peer dependency (so it's only a plain dependency now). Hardhat as a peer + dev dependency is the common pattern for plugins. As for the `tenderly` package, it could also be a peer + dev dependency if you want people to be able to upgrade it independently, but I think for this particular plugin it might not be necessary. I could be wrong here though, let me know.