### PR TITLE
Move hardhat to dev dep

### DIFF
--- a/.changeset/calm-oranges-perform.md
+++ b/.changeset/calm-oranges-perform.md
@@ -1,0 +1,5 @@
+---
+"@tenderly/hardhat-tenderly": patch
+---
+
+Move hardhat to devDependencies

--- a/packages/tenderly-hardhat/package.json
+++ b/packages/tenderly-hardhat/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "hardhat": "^2.10.2",
     "prettier": "^2.7.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.2"
@@ -53,14 +54,12 @@
     "axios": "^0.27.2",
     "ethers": "^5.7.0",
     "fs-extra": "^10.1.0",
-    "hardhat": "^2.10.2",
     "hardhat-deploy": "^0.11.14",
     "js-yaml": "^4.1.0",
     "tenderly": "^0.5.1",
     "tslog": "^4.3.1"
   },
   "peerDependencies": {
-    "hardhat": "^2.10.2",
-    "tenderly": "^0.5.1"
+    "hardhat": "^2.10.2"
   }
 }


### PR DESCRIPTION
Explanation can be found in [Move hardhat from dep to devDep #133](https://github.com/Tenderly/hardhat-tenderly/pull/133/files).