### PR TITLE
`chainId` inside specified `tenderly` network

### DIFF
--- a/.changeset/six-toes-watch.md
+++ b/.changeset/six-toes-watch.md
@@ -1,0 +1,5 @@
+---
+"@tenderly/hardhat-tenderly": patch
+---
+
+Resolved an issue where the user specifies chainId inside the tenderly network in hardhat.config.ts.

--- a/packages/tenderly-hardhat/src/utils/util.ts
+++ b/packages/tenderly-hardhat/src/utils/util.ts
@@ -53,12 +53,11 @@ export const makeVerifyContractsRequest = async (
     }
     logger.trace("Found network is:", network);
 
-    let chainId: string = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()];
-    if (hre.config.networks[network].chainId !== undefined) {
-      chainId = hre.config.networks[network].chainId!.toString();
-    }
-    if (chainId === undefined && isTenderlyNetworkName(network) && platformID !== undefined) {
+    let chainId = undefined;
+    if (isTenderlyNetworkName(network) && platformID !== undefined) {
       chainId = platformID;
+    } else {
+      chainId = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()].toString();
     }
     logger.trace(`ChainId for network '${network}' is ${chainId}`);
 


### PR DESCRIPTION
This PR resolves an issue where the user specifies `chainId` inside the `tenderly` network in `hardhat.config.ts`.