### PR TITLE
Enable clients to specify their id inside Network configuration

### DIFF
--- a/.changeset/proud-cars-wait.md
+++ b/.changeset/proud-cars-wait.md
@@ -1,0 +1,5 @@
+---
+"@tenderly/hardhat-tenderly": patch
+---
+
+Enable clients to specify their own `chainId`

--- a/packages/tenderly-hardhat/src/utils/util.ts
+++ b/packages/tenderly-hardhat/src/utils/util.ts
@@ -57,7 +57,9 @@ export const makeVerifyContractsRequest = async (
     if (isTenderlyNetworkName(network) && platformID !== undefined) {
       chainId = platformID;
     } else {
-      chainId = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()].toString();
+      chainId = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()] !== undefined ? 
+        NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()].toString() :
+        hre.network.config.chainId ;
     }
     logger.trace(`ChainId for network '${network}' is ${chainId}`);
 


### PR DESCRIPTION
Enable clients to specify their own `chainId` in the `Network` configuration, thus have a special name for a network that they can link to a specific `chainId`.
