### PR TITLE
fix: enable clients to specify their id inside Network configuration

### DIFF
--- a/.changeset/violet-keys-dream.md
+++ b/.changeset/violet-keys-dream.md
@@ -1,0 +1,5 @@
+---
+"@tenderly/hardhat-tenderly": patch
+---
+
+When looking for the chainId for the network to verify on, firstly look in the network configuration that the user specifed, then look at the base that tenderly has.

--- a/packages/tenderly-hardhat/src/utils/util.ts
+++ b/packages/tenderly-hardhat/src/utils/util.ts
@@ -56,10 +56,10 @@ export const makeVerifyContractsRequest = async (
     let chainId = undefined;
     if (isTenderlyNetworkName(network) && platformID !== undefined) {
       chainId = platformID;
-    } else {
-      chainId = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()] !== undefined ? 
-        NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()].toString() :
-        hre.network.config.chainId ;
+    } else if (hre.network?.config?.chainId !== undefined) {
+      chainId = hre.network.config.chainId.toString();
+    } else if (NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()] !== undefined) {
+      chainId = NETWORK_NAME_CHAIN_ID_MAP[network.toLowerCase()].toString();
     }
     logger.trace(`ChainId for network '${network}' is ${chainId}`);
 


### PR DESCRIPTION
Firstly look if the client specified `chainId` in the network configuration, if not, then look in the base of tenderly's networks.
