### PR TITLE
Add TENDERLY_ prefix to env variable.

### DIFF
--- a/packages/tenderly-hardhat/README.md
+++ b/packages/tenderly-hardhat/README.md
@@ -272,7 +272,7 @@ In order to successfully verify a proxy contract, please read the chapters about
 This will lead you to setup the configuration the right way, so you can verify your proxy contracts and their implementation on Tenderly.
 
 After you have successfully configured `hardhat.config.ts`, you need to populate the configuration in the format that `@nomicfoundation/hardhat-verify` plugin expects, given that this plugin uses their verification beneath for verifying proxies.
-But luckily, we have provided a way to automatically populate the configuration for you, you just need to set the `AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG=true` environment variable.
+But luckily, we have provided a way to automatically populate the configuration for you, you just need to set the `TENDERLY_AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG=true` environment variable.
 
 In order to see how this all plays out, you can clone our [@tenderly/hardhat-tenderly](https://github.com/Tenderly/hardhat-tenderly) repo and navigate to the [examples/contract-verification](https://github.com/Tenderly/hardhat-tenderly/tree/master/examples/contract-verification) directory.
 This directory contains all the possibilities that you can explore in order to verify your proxy contracts.

--- a/packages/tenderly-hardhat/src/tenderly/extender.ts
+++ b/packages/tenderly-hardhat/src/tenderly/extender.ts
@@ -78,14 +78,8 @@ export function setup() {
       extendHardhatDeploy(hre);
       logger.debug("Wrapping ethers library finished.");
     }
-    // If the user has selected automatic population of hardhat-verify `etherscan` configuration, and it in fact is some of the Tenderly networks.
-    // We should populate the configuration.
-    if (
-      process.env.AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG === "true" &&
-      (isTenderlyNetworkConfig(hre.network.config) ||
-        isTenderlyGatewayNetworkConfig(hre.network.config)) &&
-      isHttpNetworkConfig(hre.network.config)
-    ) {
+
+    if (shouldPopulateHardhatVerifyConfig(hre)) {
       logger.info(
         "Automatic population of hardhat-verify `etherscan` configuration is enabled.",
       );
@@ -229,6 +223,21 @@ const extendUpgrades = (hre: HardhatRuntimeEnvironment): void => {
     );
   }
 };
+
+// Returns true if the user has selected automatic population of hardhat-verify `etherscan` configuration through the TENDERLY_AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG env variable,
+// and the network is some of the Tenderly networks.
+function shouldPopulateHardhatVerifyConfig(
+  hre: HardhatRuntimeEnvironment,
+): boolean {
+  return (
+    // Must cover both since AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG is the legacy because we didn't use the TENDERLY_ prefix.
+    (process.env.TENDERLY_AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG === "true" ||
+      process.env.AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG === "true") &&
+    (isTenderlyNetworkConfig(hre.network.config) ||
+      isTenderlyGatewayNetworkConfig(hre.network.config)) &&
+    isHttpNetworkConfig(hre.network.config)
+  );
+}
 
 // populateHardhatVerifyConfig will populate `hre.config.etherscan` configuration of the `@nomicfoundation/hardhat-verify` plugin.
 // This function should import `@nomicfoundation/hardhat-verify` type declaration expansion of the `HardhatConfig`, but can't since there will be double overloading task error if the client application also uses `@nomicfoundation/hardhat-verify` plugin.


### PR DESCRIPTION
Add `TENDERLY_` prefix to `AUTOMATIC_POPULATE_HARDHAT_VERIFY_CONFIG` env variable to scope the env variable to the Tenderly domain.
