### PR TITLE
Improve chainId resolution and error handling

### DIFF
--- a/packages/tenderly-hardhat/src/errors.ts
+++ b/packages/tenderly-hardhat/src/errors.ts
@@ -1,0 +1,5 @@
+export class UndefinedChainIdError extends Error {
+    constructor(networkName: string) {
+        super(`Couldn't find chainId for the network: ${networkName}. \nPlease provide the chainId in the network config object`);
+    }
+}


### PR DESCRIPTION
### TL;DR
Improved chain ID resolution and error handling in the Tenderly Hardhat plugin.

### What changed?
- Created a new `UndefinedChainIdError` class for better error messaging
- Extracted chain ID resolution logic into a separate `getChainId` function
- Improved error handling when chain ID cannot be determined
- Standardized the chain ID resolution process across the plugin

### How to test?
1. Try verifying contracts on a network without a defined chain ID
2. Verify the new error message appears with the network name
3. Test contract verification on networks with valid chain IDs
4. Verify chain ID resolution works for both custom and predefined networks

### Why make this change?
To provide clearer error messages and better handle cases where chain IDs are undefined. This improves the developer experience by making it immediately clear when and why chain ID resolution fails, rather than silently failing or providing unclear error messages.