### PR TITLE
Implement client API request for verifyContractABI

### DIFF
--- a/packages/tenderly-core/src/internal/core/common/errors.ts
+++ b/packages/tenderly-core/src/internal/core/common/errors.ts
@@ -1,5 +1,6 @@
 import { TENDERLY_DASHBOARD_BASE_URL } from "../../../common/constants";
 import { configFilePath } from "../../../utils/config";
+import { HardhatError } from "hardhat/internal/core/errors";
 
 export const NETWORK_FETCH_FAILED_ERR_MSG = `There was an error during the request. Network fetch failed.`;
 export const LATEST_BLOCK_NUMBER_FETCH_FAILED_ERR_MSG = `There was an error during the request. Latest block number fetch failed.`;
@@ -14,3 +15,21 @@ export const NO_COMPILER_FOUND_FOR_CONTRACT_ERR_MSG = `No compiler configuration
 export const API_VERIFICATION_REQUEST_ERR_MSG = `Verification failed. There was an error during the API request, please contact support with the above error.`;
 export const API_ADD_CONTRACT_REQUEST_ERR_MSG = `Adding contract failed. There was an error during the API request, please contact support with the above error.`;
 export const ACCESS_TOKEN_NOT_PROVIDED_ERR_MSG = `Access token not provided at filepath ${configFilePath}.\n You can find the token at ${TENDERLY_DASHBOARD_BASE_URL}/account/authorization`;
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized. Please visit https://docs.tenderly.co/virtual-testnets/smart-contract-frameworks/hardhat#install-tenderly-cli in order to login and get your access token.");
+  }
+}
+
+export class InvalidResponseError extends Error {
+  constructor(requestName: string, responseData: any) {
+    super(`Invalid response for request: ${requestName}. Response data: ${JSON.stringify(responseData)}`);
+  }
+}
+
+export class BytecodeMissingMethodSignaturesError extends Error {
+  constructor(bytecodeMissingMethodSignatureError: any) {
+    super(`There has been a bytecode missing method signature signature error during VerifyContractABI request: ${bytecodeMissingMethodSignatureError}`);
+  }
+}

--- a/packages/tenderly-core/src/internal/core/services/TenderlyService.ts
+++ b/packages/tenderly-core/src/internal/core/services/TenderlyService.ts
@@ -6,13 +6,13 @@ import {
   ACCESS_TOKEN_NOT_PROVIDED_ERR_MSG,
   API_ADD_CONTRACT_REQUEST_ERR_MSG,
   API_VERIFICATION_REQUEST_ERR_MSG,
-  BYTECODE_MISMATCH_ERR_MSG,
+  BYTECODE_MISMATCH_ERR_MSG, BytecodeMissingMethodSignaturesError, InvalidResponseError,
   LATEST_BLOCK_NUMBER_FETCH_FAILED_ERR_MSG,
   NETWORK_FETCH_FAILED_ERR_MSG,
   NO_NEW_CONTRACTS_VERIFIED_ERR_MSG,
   NO_VERIFIABLE_CONTRACTS_ERR_MSG,
   PRINCIPAL_FETCH_FAILED_ERR_MSG,
-  PROJECTS_FETCH_FAILED_ERR_MSG,
+  PROJECTS_FETCH_FAILED_ERR_MSG, UnauthorizedError,
 } from "../common/errors";
 import {
   ContractResponse,
@@ -23,6 +23,8 @@ import {
   TenderlyForkContractUploadRequest,
   TenderlyNetwork,
   TenderlyVerifyContractsRequest,
+  VerifyContractABIRequest,
+  VerifyContractABIResponse,
 } from "../types";
 import { logger } from "../../../utils/logger";
 import {
@@ -246,6 +248,41 @@ export class TenderlyService {
         `Error in ${this.pluginName}: ${API_VERIFICATION_REQUEST_ERR_MSG}`,
       );
     }
+  }
+
+  public async verifyContractABI(
+    username: string,
+    project: string,
+    request: VerifyContractABIRequest
+  ): Promise<VerifyContractABIResponse>{
+    logger.debug("Verifying contract with ABI.");
+    if (!TenderlyApiService.isAuthenticated()) {
+      logger.error(
+        `Error in ${this.pluginName}: ${ACCESS_TOKEN_NOT_PROVIDED_ERR_MSG}`,
+      );
+      throw new UnauthorizedError();
+    }
+    
+    const tenderlyApi = TenderlyApiService.configureInstance();
+
+    const res = await tenderlyApi.post(
+      `/api/v1/account/${username}/project/${project}/contract/${request.networkId}/${request.address}/abi`,
+      {
+        contract_name: request.contractName,
+        abi: request.abi,
+      },
+    );
+    
+    if (res.data === undefined || res.data === null) {
+      throw new InvalidResponseError("verifyContractABI", res.data); 
+    }
+    
+    const response = res.data as VerifyContractABIResponse;
+    if (response.error) {
+      throw new BytecodeMissingMethodSignaturesError(response.error);
+    }
+    
+    return response;
   }
 
   public async verifyContractsMultiCompiler(

--- a/packages/tenderly-core/src/internal/core/types/VerifyContractABIRequest.ts
+++ b/packages/tenderly-core/src/internal/core/types/VerifyContractABIRequest.ts
@@ -1,0 +1,6 @@
+export interface VerifyContractABIRequest {
+  networkId: string;
+  address: string;
+  contractName: string;
+  abi: string;
+}

--- a/packages/tenderly-core/src/internal/core/types/VerifyContractABIResponse.ts
+++ b/packages/tenderly-core/src/internal/core/types/VerifyContractABIResponse.ts
@@ -1,0 +1,5 @@
+import { ContractResponse } from "./Responses";
+
+export interface VerifyContractABIResponse {
+  error: any // we will only log this error, won't return it, so it's okay to be any for now.
+}

--- a/packages/tenderly-core/src/internal/core/types/index.ts
+++ b/packages/tenderly-core/src/internal/core/types/index.ts
@@ -4,3 +4,5 @@ export * from "./Project";
 export * from "./Requests";
 export * from "./Responses";
 export * from "./TenderlyNetwork";
+export * from "./VerifyContractABIRequest";
+export * from "./VerifyContractABIResponse";

--- a/packages/tenderly-core/src/internal/lib/tenderly-lib.ts
+++ b/packages/tenderly-core/src/internal/lib/tenderly-lib.ts
@@ -2,3 +2,7 @@ import "../../utils/logger";
 import { TenderlyService } from "../core/services/TenderlyService";
 
 export { TenderlyService };
+export { 
+  VerifyContractABIRequest,
+  VerifyContractABIResponse
+} from "../core/types";


### PR DESCRIPTION
### TL;DR
Added support for verifying contract ABIs through the Tenderly API service.

### What changed?
- Introduced new `verifyContractABI` method in TenderlyService
- Added new error classes: `UnauthorizedError`, `InvalidResponseError`, and `BytecodeMissingMethodSignaturesError`
- Created new types `VerifyContractABIRequest` and `VerifyContractABIResponse`
- Exported new verification types through the tenderly-lib interface

### How to test?
1. Ensure you have a valid Tenderly access token
2. Create a `VerifyContractABIRequest` with:
   - networkId
   - contract address
   - contract name
   - ABI string
3. Call `verifyContractABI` with your username, project, and request object
4. Verify the response matches the expected `VerifyContractABIResponse` format

### Why make this change?
To provide developers with the ability to verify contract ABIs directly through the Tenderly API, enabling better contract verification workflows and improved integration with the Tenderly platform.