### PR TITLE
move VERIFICATION_TYPES to core

### DIFF
--- a/packages/tenderly-core/src/internal/core/types/index.ts
+++ b/packages/tenderly-core/src/internal/core/types/index.ts
@@ -6,3 +6,4 @@ export * from "./Responses";
 export * from "./TenderlyNetwork";
 export * from "./VerifyContractABIRequest";
 export * from "./VerifyContractABIResponse";
+export * from "./verification-types";

--- a/packages/tenderly-core/src/internal/core/types/verification-types.ts
+++ b/packages/tenderly-core/src/internal/core/types/verification-types.ts
@@ -1,0 +1,6 @@
+export const VERIFICATION_TYPES = {
+  FORK: "fork",
+  PRIVATE: "private",
+  PUBLIC: "public",
+  DEVNET: "devnet",
+};

--- a/packages/tenderly-core/src/internal/lib/tenderly-lib.ts
+++ b/packages/tenderly-core/src/internal/lib/tenderly-lib.ts
@@ -4,5 +4,6 @@ import { TenderlyService } from "../core/services/TenderlyService";
 export { TenderlyService };
 export { 
   VerifyContractABIRequest,
-  VerifyContractABIResponse
+  VerifyContractABIResponse,
+  VERIFICATION_TYPES,
 } from "../core/types";

--- a/packages/tenderly-hardhat/src/constants.ts
+++ b/packages/tenderly-hardhat/src/constants.ts
@@ -1,10 +1,4 @@
 export const PLUGIN_NAME = "hardhat-tenderly";
 export const DEFAULT_CHAIN_ID = "31337";
-export const VERIFICATION_TYPES = {
-  FORK: "fork",
-  PRIVATE: "private",
-  PUBLIC: "public",
-  DEVNET: "devnet",
-};
 export const CONTRACT_NAME_PLACEHOLDER =
   "HARDHAT_TENDERLY_CONTRACT_NAME_PLACEHOLDER";

--- a/packages/tenderly-hardhat/src/utils/get-verification-type.ts
+++ b/packages/tenderly-hardhat/src/utils/get-verification-type.ts
@@ -1,7 +1,7 @@
 import { isTenderlyNetworkConfig } from "./util";
-import { VERIFICATION_TYPES } from "../constants";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { TenderlyNetwork } from "../TenderlyNetwork";
+import { VERIFICATION_TYPES } from "@tenderly/api-client";
 
 export async function getVerificationType(
   hre: HardhatRuntimeEnvironment,


### PR DESCRIPTION
### TL;DR
Moved verification types from hardhat package to core package and updated imports accordingly.

### What changed?
- Created new `verification-types.ts` file in tenderly-core package
- Moved `VERIFICATION_TYPES` constant from hardhat package to core package
- Updated imports to use the new location of `VERIFICATION_TYPES`
- Added export for verification types in core package index

### How to test?
1. Import `VERIFICATION_TYPES` from `@tenderly/api-client`
2. Verify the constant contains the expected values: "fork", "private", "public", and "devnet"
3. Ensure existing functionality using verification types continues to work as expected

### Why make this change?
Centralizes verification types in the core package, making them more accessible across different packages and reducing code duplication. This change follows better architectural practices by maintaining these common types in a single, shared location.