### PR TITLE
Implement ABI verification depending on verificationType on tenderly-hardhat

### DIFF
--- a/packages/tenderly-hardhat/src/Tenderly.ts
+++ b/packages/tenderly-hardhat/src/Tenderly.ts
@@ -2,7 +2,7 @@ import { sep } from "path";
 import * as fs from "fs-extra";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { TenderlyService } from "@tenderly/api-client";
+import { TenderlyService, VERIFICATION_TYPES } from "@tenderly/api-client";
 import {
   TenderlyArtifact,
   TenderlyContractUploadRequest,
@@ -25,7 +25,7 @@ import {
   makeVerifyContractsRequest,
   resolveDependencies,
 } from "./utils/util";
-import { DEFAULT_CHAIN_ID, PLUGIN_NAME, VERIFICATION_TYPES } from "./constants";
+import { DEFAULT_CHAIN_ID, PLUGIN_NAME } from "./constants";
 import { TenderlyNetwork } from "./TenderlyNetwork";
 import { ProxyPlaceholderName } from "./index";
 import { VerificationService } from "./verification";
@@ -44,7 +44,10 @@ export class Tenderly {
 
     this.env = hre;
     this.tenderlyNetwork = new TenderlyNetwork(hre);
-    this.verificationService = new VerificationService(this.tenderlyService);
+    this.verificationService = new VerificationService(
+      this.tenderlyService, 
+      this.tenderlyNetwork,
+    );
 
     logger.debug("Created Tenderly plugin.");
   }
@@ -61,6 +64,7 @@ export class Tenderly {
           contract.name,
         );
       }
+      return;
     }
 
     // If there are proxy contracts, we can run the task without further processing.
@@ -191,7 +195,7 @@ export class Tenderly {
       else throw e;
     }
     
-    return chainId === 300 || chainId === 324 || chainId === 37111
+    return (chainId === 300 || chainId === 324 || chainId === 37111)
   }
 
   public async verifyForkMultiCompilerAPI(

--- a/packages/tenderly-hardhat/src/verification/errors.ts
+++ b/packages/tenderly-hardhat/src/verification/errors.ts
@@ -1,0 +1,5 @@
+export class VerifyContractABIOnDevnetNotSupportedError extends Error {
+  constructor() {
+    super("Verifying contract ABIs on devnet is not supported");
+  }
+}

--- a/packages/tenderly-hardhat/src/verification/service.ts
+++ b/packages/tenderly-hardhat/src/verification/service.ts
@@ -1,4 +1,4 @@
-import { TenderlyService } from "@tenderly/api-client";
+import { TenderlyService, VERIFICATION_TYPES } from "@tenderly/api-client";
 import { 
   VerifyContractABIRequest,
   VerifyContractABIResponse
@@ -6,14 +6,20 @@ import {
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { throwIfUsernameOrProjectNotSet } from "../errors";
 import { getChainId } from "../utils/util";
+import { TenderlyNetwork } from "../TenderlyNetwork";
+import { getVerificationType, isVerificationOnVnet } from "../utils";
+import { VerifyContractABIOnDevnetNotSupportedError } from "./errors";
 
 export class VerificationService {
   private readonly tenderlyService: TenderlyService;
+  private readonly tenderlyNetwork: TenderlyNetwork;
   
   constructor(
-    tenderlyService: TenderlyService
+    tenderlyService: TenderlyService,
+    tenderlyNetwork: TenderlyNetwork,
   ) {
     this.tenderlyService = tenderlyService;
+    this.tenderlyNetwork = tenderlyNetwork;
   }
   
   public async verifyContractABI(
@@ -23,24 +29,74 @@ export class VerificationService {
   ): Promise<VerifyContractABIResponse> {
     await throwIfUsernameOrProjectNotSet(hre);
     
-    const networkId = await getChainId(hre);
+    const authRequest = await this.makeVerifyContractABIRequest(
+      hre,
+      address,
+      contractName,
+    );
+    
+    // if the verificationType is on project,
+    // add the contract to the project, first so ABI verification doesn't break because of that.
+    if (authRequest.verificationType === VERIFICATION_TYPES.PRIVATE || VERIFICATION_TYPES.PUBLIC) {
+      await this.tenderlyService.addContractToProject(
+        authRequest.username,
+        authRequest.project,
+        {
+          network_id: authRequest.request.networkId,
+          address: authRequest.request.address,
+          display_name: authRequest.request.contractName,
+        }
+      )
+    }
+    
+    return this.tenderlyService.verifyContractABI(
+      authRequest.username,
+      authRequest.project,
+      authRequest.verificationType,
+      authRequest.request,
+    )
+  }
+  
+  private async makeVerifyContractABIRequest(
+    hre: HardhatRuntimeEnvironment,
+    address: string,
+    contractName: string,
+  ): Promise<AuthenticatedVerifyContractABIRequest> {
+    const verificationType = await getVerificationType(hre, this.tenderlyNetwork);
+    if (verificationType === VERIFICATION_TYPES.DEVNET) {
+      throw new VerifyContractABIOnDevnetNotSupportedError()
+    }
+
+    let networkId = (await getChainId(hre)).toString();
+    if (await isVerificationOnVnet(verificationType)) {
+      networkId = this.tenderlyNetwork.forkID!;
+    }
+
     const abi = (await hre.artifacts.readArtifact(contractName)).abi;
     const abiString = JSON.stringify(abi);
-    
+
     const request: VerifyContractABIRequest = {
       networkId: networkId.toString(),
       address: address,
       contractName: contractName,
       abi: abiString,
     }
-    
+
     const username = hre.config.tenderly.username;
     const project = hre.config.tenderly.project;
     
-    return await this.tenderlyService.verifyContractABI(
+    return {
       username,
       project,
+      verificationType,
       request,
-    )
+    }
   }
+}
+
+interface AuthenticatedVerifyContractABIRequest {
+  username: string;
+  project: string;
+  verificationType: string;
+  request: VerifyContractABIRequest;
 }


### PR DESCRIPTION
### TL;DR
Enhanced contract verification functionality in the Tenderly Hardhat plugin by adding support for different verification types and improving error handling.

### What changed?
- Added verification type checks before contract ABI verification
- Introduced automatic contract addition to projects before ABI verification
- Created new error handling for devnet verification attempts
- Restructured verification service to handle different network types (including virtual networks)
- Added support for fork ID usage in virtual network verifications

### How to test?
1. Attempt to verify a contract ABI on a regular network
2. Try verifying a contract on a virtual network to ensure fork ID is properly used
3. Verify that attempting to verify on devnet throws the appropriate error
4. Test automatic contract addition to project before ABI verification

### Why make this change?
To provide more robust contract verification handling across different network types and improve the user experience by adding proper error handling and automatic contract registration. This ensures more reliable contract verification processes and better support for various Tenderly network configurations.