### PR TITLE
chore: fix error message for version validation

### DIFF
--- a/scripts/set-release-version.ts
+++ b/scripts/set-release-version.ts
@@ -12,7 +12,7 @@ function main() {
     throw new Error("Version to release must be a number.");
   }
   if (versionToRelease < 1 || versionToRelease > 2) {
-    throw new Error("Version to release must be between 0 and 2.");
+    throw new Error("Version to release must be between 1 and 2.");
   }
 
   if (versionToRelease == 1) {


### PR DESCRIPTION
I’ve corrected an issue in the version validation logic.

The check was throwing an error for versions outside the range 1 to 2, but the error message mentioned 0 to 2. I’ve updated the message to match the intended version range (1 to 2).

Now, the validation and the error message are aligned.
